### PR TITLE
linux-mt: Fixes compilation fails when using O=output option in make

### DIFF
--- a/linux-mt/arch/arm64/boot/Makefile
+++ b/linux-mt/arch/arm64/boot/Makefile
@@ -20,6 +20,12 @@ targets := Image Image.bz2 Image.gz Image.lz4 Image.lzma Image.lzo Image.zst
 
 $(obj)/Image: vmlinux FORCE
 	$(call if_changed,objcopy)
+	if [ ! -f $(obj)/mkimage ]; then \
+	    ln -s $(srctree)/../../../$(obj)/mkimage $(obj)/mkimage; \
+	fi
+	if [ ! -f $(obj)/bpi_script ]; then \
+	    ln -s $(srctree)/../../../$(obj)/bpi_script $(obj)/bpi_script; \
+	fi
 	$(obj)/mkimage -E -B 0x1000 -p 0x1000 -f $(obj)/bpi_script $(obj)/uImage
 
 $(obj)/Image.bz2: $(obj)/Image FORCE

--- a/linux-mt/include/linux/lzma/Types.h
+++ b/linux-mt/include/linux/lzma/Types.h
@@ -4,7 +4,11 @@
 #ifndef __7Z_TYPES_H
 #define __7Z_TYPES_H
 
-#include <stddef.h>
+#ifdef __KERNEL__
+#	include <linux/stddef.h>
+#else
+#	include <stddef.h>
+#endif
 
 #ifdef _WIN32
 #include <windows.h>

--- a/linux-mt/lib/lzma/Makefile
+++ b/linux-mt/lib/lzma/Makefile
@@ -4,4 +4,4 @@ lzma_decompress-objs := LzmaDec.o
 obj-$(CONFIG_LZMA_COMPRESS) += lzma_compress.o
 obj-$(CONFIG_LZMA_DECOMPRESS) += lzma_decompress.o
 
-EXTRA_CFLAGS += -Iinclude/linux -Iinclude/linux/lzma -include types.h
+EXTRA_CFLAGS += -I $(srctree)/include/linux -I $(srctree)/include/linux/lzma -include $(srctree)/include/linux/types.h


### PR DESCRIPTION
Hi,

Please accept this fix for your branch.
I was struggling to build Linux Kernel using simple command like:
```
make ARCH=arm64 O=build-mt7988 -j24
```
and the compilation failed with:
```
make -f ../scripts/Makefile.build obj=fs/jffs2 \
need-builtin=1 \
need-modorder=1 \

  aarch64-linux-gnu-gcc -Wp,-MMD,fs/jffs2/.compr_lzma.o.d -nostdinc -I../arch/arm64/include -I./arch/arm64/include/generated -I../include -I./include -I../arch/arm64/include/uapi -I./arch/arm64/include/generated/uapi -I../include/uapi -I./include/generated/uapi -include ../include/linux/compiler-version.h -include ../include/linux/kconfig.h -include ../include/linux/compiler_types.h -D__KERNEL__ -mlittle-endian -DKASAN_SHADOW_SCALE_SHIFT= -fmacro-prefix-map=../= -Wall -Wundef -Werror=strict-prototypes -Wno-trigraphs -fno-strict-aliasing -fno-common -fshort-wchar -fno-PIE -Werror=implicit-function-declaration -Werror=implicit-int -Werror=return-type -Wno-format-security -std=gnu11 -mgeneral-regs-only -DCONFIG_CC_HAS_K_CONSTRAINT=1 -Wno-psabi -mabi=lp64 -fno-asynchronous-unwind-tables -fno-unwind-tables -mbranch-protection=none -Wa,-march=armv8.5-a -DARM64_ASM_ARCH='"armv8.5-a"' -DKASAN_SHADOW_SCALE_SHIFT= -fno-delete-null-pointer-checks -Wno-frame-address -Wno-format-truncation -Wno-format-overflow -Wno-address-of-packed-member -O2 -fno-allow-store-data-races -Wframe-larger-than=2048 -fstack-protector -Wno-main -Wno-unused-but-set-variable -Wno-unused-const-variable -Wno-dangling-pointer -fno-omit-frame-pointer -fno-optimize-sibling-calls -fno-stack-clash-protection -Wdeclaration-after-statement -Wvla -Wno-pointer-sign -Wcast-function-type -Wno-stringop-truncation -Wno-stringop-overflow -Wno-restrict -Wno-maybe-uninitialized -Wno-array-bounds -Wno-alloc-size-larger-than -Wimplicit-fallthrough=5 -fno-strict-overflow -fno-stack-check -fconserve-stack -Werror=date-time -Werror=incompatible-pointer-types -Werror=designated-init -Wno-packed-not-aligned -g -fno-var-tracking -femit-struct-debug-baseonly -mstack-protector-guard=sysreg -mstack-protector-guard-reg=sp_el0 -mstack-protector-guard-offset=1096 -Iinclude/linux -Ilib/lzma -I ../fs/jffs2 -I ./fs/jffs2    -DKBUILD_MODFILE='"fs/jffs2/jffs2"' -DKBUILD_BASENAME='"compr_lzma"' -DKBUILD_MODNAME='"jffs2"' -D__KBUILD_MODNAME=kmod_jffs2 -c -o fs/jffs2/compr_lzma.o ../fs/jffs2/compr_lzma.c  
In file included from ../include/linux/lzma/LzmaDec.h:7,
                 from ../include/linux/lzma.h:35,
                 from ../fs/jffs2/compr_lzma.c:10:
../include/linux/lzma/Types.h:7:10: fatal error: stddef.h: No such file or directory
    7 | #include <stddef.h>
      |          ^~~~~~~~~~
compilation terminated.
make[4]: *** [../scripts/Makefile.build:250: fs/jffs2/compr_lzma.o] Error 1
make[3]: *** [../scripts/Makefile.build:500: fs/jffs2] Error 2
make[2]: *** [../scripts/Makefile.build:500: fs] Error 2
make[1]: *** [/home/EasyNetDev/Devel/BPi-R4/BPI-R4-bsp-6.1/linux-mt/Makefile:2014: .] Error 2
make[1]: Leaving directory '/home/EasyNetDev/Devel/BPi-R4/BPI-R4-bsp-6.1/linux-mt/build-mt7988'
make: *** [Makefile:238: __sub-make] Error 2
make: Leaving directory '/home/EasyNetDev/Devel/BPi-R4/BPI-R4-bsp-6.1/linux-mt'
```

File include/linux/lzma/Types.h needs to compile with linux/stddef.h if `__KERNEL__` is defined or just stddef.h in case is not.
